### PR TITLE
Add package.json files array with dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": ["dist"],
   "repository": {
     "type": "git",
     "url": "https://github.com/dabroek/node-cache-manager-redis-store.git"


### PR DESCRIPTION
The TypeScript definition file was added to the repository but it was not published on the npm registry. Adding the `dist` folder to the `package.json` `files` array, we ensure that all files on that dir will be published.